### PR TITLE
Prealloc memory stream

### DIFF
--- a/packaging/nuget/NServiceBus.DataBus.AzureBlobStorage.nuspec
+++ b/packaging/nuget/NServiceBus.DataBus.AzureBlobStorage.nuspec
@@ -15,7 +15,7 @@
     <tags>$tags$</tags>
     <dependencies>
       <dependency id="WindowsAzure.Storage" version="[7.0.0, 8.0.0)" />
-      <dependency id="NServiceBus" version="[6.0.0-beta, 7.0.0)" />
+      <dependency id="NServiceBus" version="[6.0.0-beta0004, 7.0.0)" />
     </dependencies>
   </metadata>
   <files>

--- a/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
@@ -36,7 +36,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
@@ -36,11 +36,12 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0001\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -54,13 +55,13 @@
     <Compile Include="When_sending_databus_properties.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup>
     <ProjectReference Include="..\DataBus\NServiceBus.DataBus.AzureBlobStorage.csproj">
       <Project>{fb6302d6-25dc-470d-876e-d36ef81afc97}</Project>
       <Name>NServiceBus.DataBus.AzureBlobStorage</Name>
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/src/AcceptanceTests/packages.config
+++ b/src/AcceptanceTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
 </packages>

--- a/src/AcceptanceTests/packages.config
+++ b/src/AcceptanceTests/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
+  <package id="NUnit" version="3.2.1" targetFramework="net452" />
 </packages>

--- a/src/DataBus/AzureDataBus.cs
+++ b/src/DataBus/AzureDataBus.cs
@@ -8,6 +8,7 @@ namespace NServiceBus
     /// </summary>
     public class AzureDataBus : DataBusDefinition
     {
+        /// <summary>The feature to enable when this databus is selected.</summary>
         protected override Type ProvidedByFeature()
         {
             return typeof(DataBus.AzureBlobStorage.AzureDataBusPersistence);

--- a/src/DataBus/BlobStorageDataBus.cs
+++ b/src/DataBus/BlobStorageDataBus.cs
@@ -7,7 +7,6 @@ namespace NServiceBus.DataBus.AzureBlobStorage
     using System.Net;
     using System.Threading;
     using System.Threading.Tasks;
-    using DataBus;
     using Logging;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Blob;
@@ -25,9 +24,10 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
         public async Task<Stream> Get(string key)
         {
-            Stream stream = new MemoryStream();
             var blob = container.GetBlockBlobReference(Path.Combine(settings.BasePath, key));
             await blob.FetchAttributesAsync().ConfigureAwait(false);
+
+            var stream = new MemoryStream((int) blob.Properties.Length);
 
             blob.ServiceClient.DefaultRequestOptions.ParallelOperationThreadCount = settings.NumberOfIOThreads;
             container.ServiceClient.DefaultRequestOptions.RetryPolicy = retryPolicy;
@@ -158,7 +158,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         CloudBlobContainer container;
         DataBusSettings settings;
         Timer timer;
-        static ILog logger = LogManager.GetLogger(typeof(IDataBus));
         ExponentialRetry retryPolicy;
+        static ILog logger = LogManager.GetLogger(typeof(IDataBus));
     }
 }

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -14,7 +14,7 @@
         /// <summary>
         /// Sets the number of retries used by the blob storage client. Default is 5.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> MaxRetries(this DataBusExtentions<AzureDataBus> config, int maxRetries)
+        public static DataBusExtensions<AzureDataBus> MaxRetries(this DataBusExtensions<AzureDataBus> config, int maxRetries)
         {
             if (maxRetries < 0)
             {
@@ -28,7 +28,7 @@
         /// <summary>
         /// Sets backoff intervall used by the blob storage client. Default is 30 seconds.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> BackOffInterval(this DataBusExtentions<AzureDataBus> config, int backOffInterval)
+        public static DataBusExtensions<AzureDataBus> BackOffInterval(this DataBusExtensions<AzureDataBus> config, int backOffInterval)
         {
             if (backOffInterval < 0)
             {
@@ -42,7 +42,7 @@
         /// <summary>
         /// Sets the block size used by the blob storage client. Default is 4mb which also is the maximum for blob storage.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> BlockSize(this DataBusExtentions<AzureDataBus> config, int blockSize)
+        public static DataBusExtensions<AzureDataBus> BlockSize(this DataBusExtensions<AzureDataBus> config, int blockSize)
         {
             if (blockSize <= 0)
             {
@@ -61,7 +61,7 @@
         /// <summary>
         /// Sets the number threads used the blob storage client. Default is 5.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> NumberOfIOThreads(this DataBusExtentions<AzureDataBus> config, int numberOfIOThreads)
+        public static DataBusExtensions<AzureDataBus> NumberOfIOThreads(this DataBusExtensions<AzureDataBus> config, int numberOfIOThreads)
         {
             if (numberOfIOThreads <= 0)
             {
@@ -75,7 +75,7 @@
         /// <summary>
         /// The connection string to use. Default is `UseDevelopmentStorage=true`.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> ConnectionString(this DataBusExtentions<AzureDataBus> config, string connectionString)
+        public static DataBusExtensions<AzureDataBus> ConnectionString(this DataBusExtensions<AzureDataBus> config, string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
             {
@@ -89,7 +89,7 @@
         /// <summary>
         /// The blob container name to use. Default is ``.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> Container(this DataBusExtentions<AzureDataBus> config, string containerName)
+        public static DataBusExtensions<AzureDataBus> Container(this DataBusExtensions<AzureDataBus> config, string containerName)
         {
 
             if (!IsValidBlobContainerName(containerName))
@@ -112,7 +112,7 @@
         /// <summary>
         /// The base path within the container. Default is ``.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> BasePath(this DataBusExtentions<AzureDataBus> config, string basePath)
+        public static DataBusExtensions<AzureDataBus> BasePath(this DataBusExtensions<AzureDataBus> config, string basePath)
         {
             var value = basePath != null ? basePath : " ";
             var spacesOnly = value.Trim().Length == 0 && value.Length != 0;
@@ -130,7 +130,7 @@
         /// Sets the default TTL to use for messages with no specific TTL. By default no TTL is set and messages are kept forever.
         /// Note that messages in flight or in the error queue can no longer be processed when DataBus entry has been removed.
         /// </summary>
-        public static DataBusExtentions<AzureDataBus> DefaultTTL(this DataBusExtentions<AzureDataBus> config, long defaultTTLInSeconds)
+        public static DataBusExtensions<AzureDataBus> DefaultTTL(this DataBusExtensions<AzureDataBus> config, long defaultTTLInSeconds)
         {
             if (defaultTTLInSeconds < 0)
             {
@@ -146,7 +146,7 @@
                    Regex.IsMatch((string)containerName, @"^(([a-z\d]((-(?=[a-z\d]))|([a-z\d])){2,62})|(\$root))$");
         }
 
-        static DataBusSettings GetSettings(DataBusExtentions<AzureDataBus> config)
+        static DataBusSettings GetSettings(DataBusExtensions<AzureDataBus> config)
         {
             DataBusSettings settings;
             if (!config.GetSettings().TryGet(out settings))

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -6,8 +6,14 @@
     using DataBus;
     using DataBus.AzureBlobStorage;
 
+    /// <summary>
+    /// Configuration options for the Azure BlobStorage DataBus.
+    /// </summary>
     public static class ConfigureAzureDataBus
     {
+        /// <summary>
+        /// Sets the number of retries used by the blob storage client. Default is 5.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> MaxRetries(this DataBusExtentions<AzureDataBus> config, int maxRetries)
         {
             if (maxRetries < 0)
@@ -19,6 +25,9 @@
             return config;
         }
 
+        /// <summary>
+        /// Sets backoff intervall used by the blob storage client. Default is 30 seconds.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> BackOffInterval(this DataBusExtentions<AzureDataBus> config, int backOffInterval)
         {
             if (backOffInterval < 0)
@@ -30,6 +39,9 @@
             return config;
         }
 
+        /// <summary>
+        /// Sets the block size used by the blob storage client. Default is 4mb which also is the maximum for blob storage.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> BlockSize(this DataBusExtentions<AzureDataBus> config, int blockSize)
         {
             if (blockSize <= 0)
@@ -46,6 +58,9 @@
             return config;
         }
 
+        /// <summary>
+        /// Sets the number threads used the blob storage client. Default is 5.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> NumberOfIOThreads(this DataBusExtentions<AzureDataBus> config, int numberOfIOThreads)
         {
             if (numberOfIOThreads <= 0)
@@ -57,6 +72,9 @@
             return config;
         }
 
+        /// <summary>
+        /// The connection string to use. Default is `UseDevelopmentStorage=true`.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> ConnectionString(this DataBusExtentions<AzureDataBus> config, string connectionString)
         {
             if (string.IsNullOrWhiteSpace(connectionString))
@@ -68,6 +86,9 @@
             return config;
         }
 
+        /// <summary>
+        /// The blob container name to use. Default is ``.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> Container(this DataBusExtentions<AzureDataBus> config, string containerName)
         {
 
@@ -88,6 +109,9 @@
             return config;
         }
 
+        /// <summary>
+        /// The base path within the container. Default is ``.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> BasePath(this DataBusExtentions<AzureDataBus> config, string basePath)
         {
             var value = basePath != null ? basePath : " ";
@@ -102,6 +126,10 @@
             return config;
         }
 
+        /// <summary>
+        /// Sets the default TTL to use for messages with no specific TTL. By default no TTL is set and messages are kept forever.
+        /// Note that messages in flight or in the error queue can no longer be processed when DataBus entry has been removed.
+        /// </summary>
         public static DataBusExtentions<AzureDataBus> DefaultTTL(this DataBusExtentions<AzureDataBus> config, long defaultTTLInSeconds)
         {
             if (defaultTTLInSeconds < 0)

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=4.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -69,7 +69,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0001\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Obsolete, Version=4.1.0.0, Culture=neutral, PublicKeyToken=1ca091877d12ca03, processorArchitecture=MSIL">

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -25,7 +25,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\binaries\NServiceBus.DataBus.AzureBlobStorage.xml</DocumentationFile>
-    <NoWarn>1591, 0618</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
     <UseVSHostingProcess>false</UseVSHostingProcess>
@@ -38,7 +37,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\..\binaries\NServiceBus.DataBus.AzureBlobStorage.xml</DocumentationFile>
-    <NoWarn>1591</NoWarn>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <Prefer32Bit>false</Prefer32Bit>
     <UseVSHostingProcess>false</UseVSHostingProcess>

--- a/src/DataBus/obsoletes.cs
+++ b/src/DataBus/obsoletes.cs
@@ -1,4 +1,6 @@
-﻿namespace NServiceBus
+﻿#pragma warning disable 1591
+
+namespace NServiceBus
 {
     using Features;
 

--- a/src/DataBus/packages.config
+++ b/src/DataBus/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />

--- a/src/DataBus/packages.config
+++ b/src/DataBus/packages.config
@@ -6,7 +6,7 @@
   <package id="Microsoft.Data.Edm" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
-  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
   <package id="NuGetPackager" version="0.6.0" targetFramework="net452" developmentDependency="true" />
   <package id="Obsolete.Fody" version="4.1.0" targetFramework="net452" developmentDependency="true" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />

--- a/src/Tests/APIApprovals.Approve.approved.txt
+++ b/src/Tests/APIApprovals.Approve.approved.txt
@@ -21,14 +21,14 @@ namespace NServiceBus
     }
     public class static ConfigureAzureDataBus
     {
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> BackOffInterval(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, int backOffInterval) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> BasePath(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, string basePath) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> BlockSize(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, int blockSize) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> ConnectionString(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, string connectionString) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> Container(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, string containerName) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> DefaultTTL(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, long defaultTTLInSeconds) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> MaxRetries(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, int maxRetries) { }
-        public static NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> NumberOfIOThreads(this NServiceBus.DataBus.DataBusExtentions<NServiceBus.AzureDataBus> config, int numberOfIOThreads) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BackOffInterval(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int backOffInterval) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BasePath(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string basePath) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BlockSize(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int blockSize) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> ConnectionString(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string connectionString) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> Container(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string containerName) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> DefaultTTL(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, long defaultTTLInSeconds) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> MaxRetries(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int maxRetries) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> NumberOfIOThreads(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int numberOfIOThreads) { }
     }
 }
 namespace NServiceBus.Config

--- a/src/Tests/APIApprovals.cs
+++ b/src/Tests/APIApprovals.cs
@@ -15,6 +15,7 @@ public class APIApprovals
     [MethodImpl(MethodImplOptions.NoInlining)]
     public void Approve()
     {
+        Directory.SetCurrentDirectory(TestContext.CurrentContext.TestDirectory);
         var assemblyPath = Path.GetFullPath(typeof(AzureDataBus).Assembly.Location);
         var asm = AssemblyDefinition.ReadAssembly(assemblyPath);
         var publicApi = Filter(PublicApiGenerator.CreatePublicApiForAssembly(asm));

--- a/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
+++ b/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
@@ -94,11 +94,12 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0001\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="nunit.framework">
-      <HintPath>..\packages\NUnit.2.6.4\lib\nunit.framework.dll</HintPath>
+    <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">
+      <HintPath>..\packages\NUnit.3.2.1\lib\net45\nunit.framework.dll</HintPath>
+      <Private>True</Private>
     </Reference>
     <Reference Include="Rhino.Mocks">
       <HintPath>..\packages\RhinoMocks.3.6.1\lib\net\Rhino.Mocks.dll</HintPath>

--- a/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
+++ b/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
@@ -94,7 +94,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NServiceBus.Core, Version=6.0.0.0, Culture=neutral, PublicKeyToken=9fc386479f8a226c, processorArchitecture=MSIL">
-      <HintPath>..\packages\NServiceBus.6.0.0-beta0003\lib\net452\NServiceBus.Core.dll</HintPath>
+      <HintPath>..\packages\NServiceBus.6.0.0-beta0004\lib\net452\NServiceBus.Core.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="nunit.framework, Version=3.2.1.0, Culture=neutral, PublicKeyToken=2638cd05610744eb, processorArchitecture=MSIL">

--- a/src/Tests/When_using_AzureDataBusGuard.cs
+++ b/src/Tests/When_using_AzureDataBusGuard.cs
@@ -9,40 +9,35 @@
     public class When_using_AzureDataBusGuard
     {
         [Test]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Should_not_allow_negative_maximum_retries()
         {
-            config.MaxRetries(-1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.MaxRetries(-1));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Should_not_allow_negative_backoff_interval()
         {
-            config.BackOffInterval(-1);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.BackOffInterval(-1));
         }
 
         [TestCase(0)]
         [TestCase(ConfigureAzureDataBus.MaxBlockSize + 1)]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Should_not_allow_block_size_more_than_4MB_or_less_than_one_byte(int blockSize)
         {
-            config.BlockSize(blockSize);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.BlockSize(blockSize));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Should_not_allow_invalid_number_of_threads()
         {
-            config.NumberOfIOThreads(0);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.NumberOfIOThreads(0));
         }
 
         [TestCase("")]
         [TestCase(null)]
-        [ExpectedException(typeof(ArgumentException))]
         public void Should_not_allow_invalid_connection_string(string connectionString)
         {
-            config.ConnectionString(connectionString);
+            Assert.Throws<ArgumentException>(() => config.ConnectionString(connectionString));
         }
 
         [TestCase("con")]
@@ -63,25 +58,22 @@
         [TestCase("co$ntainer")]
         [TestCase("over-63-letters-long-container-name-AAAAAAAAAAAAAAAAAAAAAAAAAAAB")]
         [TestCase(null)]
-        [ExpectedException(typeof(ArgumentException))]
         public void Should_not_allow_invalid_container_name(string containerName)
         {
-            config.Container(containerName);
+            Assert.Throws<ArgumentException>(() => config.Container(containerName));
         }
 
         [TestCase(null)]
         [TestCase(" ")]
-        [ExpectedException(typeof(ArgumentException))]
         public void Should_not_allow_null_or_whitespace_base_path(string basePath)
         {
-            config.BasePath(basePath);
+            Assert.Throws<ArgumentException>(() => config.BasePath(basePath));
         }
 
         [Test]
-        [ExpectedException(typeof(ArgumentOutOfRangeException))]
         public void Should_not_allow_negative_default_time_to_live()
         {
-            config.DefaultTTL(-1L);
+            Assert.Throws<ArgumentOutOfRangeException>(() => config.DefaultTTL(-1L));
         }
 
         DataBusExtentions<AzureDataBus> config = new DataBusExtentions<AzureDataBus>(new SettingsHolder());

--- a/src/Tests/When_using_AzureDataBusGuard.cs
+++ b/src/Tests/When_using_AzureDataBusGuard.cs
@@ -76,6 +76,6 @@
             Assert.Throws<ArgumentOutOfRangeException>(() => config.DefaultTTL(-1L));
         }
 
-        DataBusExtentions<AzureDataBus> config = new DataBusExtentions<AzureDataBus>(new SettingsHolder());
+        DataBusExtensions<AzureDataBus> config = new DataBusExtensions<AzureDataBus>(new SettingsHolder());
     }
 }

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -8,7 +8,7 @@
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
-  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
+  <package id="NServiceBus" version="6.0.0-beta0004" targetFramework="net452" />
   <package id="NUnit" version="3.2.1" targetFramework="net452" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />

--- a/src/Tests/packages.config
+++ b/src/Tests/packages.config
@@ -8,8 +8,8 @@
   <package id="Microsoft.Data.OData" version="5.7.0" targetFramework="net45" />
   <package id="Microsoft.Data.Services.Client" version="5.7.0" targetFramework="net45" />
   <package id="Mono.Cecil" version="0.9.6.1" targetFramework="net452" />
-  <package id="NServiceBus" version="6.0.0-beta0001" targetFramework="net452" />
-  <package id="NUnit" version="2.6.4" targetFramework="net45" />
+  <package id="NServiceBus" version="6.0.0-beta0003" targetFramework="net452" />
+  <package id="NUnit" version="3.2.1" targetFramework="net452" />
   <package id="RhinoMocks" version="3.6.1" targetFramework="net45" />
   <package id="System.Spatial" version="5.7.0" targetFramework="net45" />
   <package id="WindowsAzure.Storage" version="7.0.0" targetFramework="net452" />


### PR DESCRIPTION
Prealloc a MemoryStream instance right to the proper length. This removes the copying and reallocating (doubling capacity) everytime the stream is no long enough.
