### PR TITLE
Continue cleanup if blobs are missing

### DIFF
--- a/src/DataBus/BlobStorageDataBus.cs
+++ b/src/DataBus/BlobStorageDataBus.cs
@@ -75,17 +75,25 @@ namespace NServiceBus.DataBus.AzureBlobStorage
                 {
                     if (blockBlob == null) continue;
 
-                    blockBlob.FetchAttributes();
-                    var validUntil = GetValidUntil(blockBlob, settings.TTL);
-                    if (validUntil < DateTime.UtcNow)
+                    try
                     {
-                        blockBlob.DeleteIfExists();
+                        blockBlob.FetchAttributes();
+                        var validUntil = GetValidUntil(blockBlob, settings.TTL);
+                        if (validUntil < DateTime.UtcNow)
+                        {
+                            blockBlob.DeleteIfExists();
+                        }
+                    }
+                    catch (Exception ex)
+                    {
+                        // Another endpoint instance could have deleted the blob just a moment ago after blobs were listed by the current instance
+                        logger.WarnFormat($"{nameof(BlobStorageDataBus)} has encountered an exception while deleting blob {blockBlob.Name}.", ex);
                     }
                 }
             }
             catch (StorageException ex) // needs to stay as it runs on a background thread
             {
-                logger.Warn(ex.Message);
+                logger.WarnFormat($"{nameof(BlobStorageDataBus)} has encountered an exception.", ex);
             }
             finally
             {


### PR DESCRIPTION
Fixes #1 by not breaking the `foreach` loop, allowing to resume on the rest of blobs.