### PR TITLE
Project cleanup

### DIFF
--- a/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
@@ -1,18 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <ProjectReference Include="..\DataBus\NServiceBus.DataBus.AzureBlobStorage.csproj" />
-    
-    <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   </ItemGroup>
+
 </Project>

--- a/src/DataBus/AssemblyInfo.cs
+++ b/src/DataBus/AssemblyInfo.cs
@@ -1,10 +1,5 @@
-﻿using System.Reflection;
-using System.Runtime.CompilerServices;
+﻿using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
 
-[assembly: AssemblyTitle("NServiceBus.DataBus.AzureBlobStorage")]
-[assembly: AssemblyCopyright("Copyright NServiceBus. All rights reserved")]
-[assembly: AssemblyProduct("NServiceBus.Core")]
-[assembly: AssemblyCompany("NServiceBus Ltd.")]
 [assembly: ComVisible(false)]
 [assembly: InternalsVisibleTo("NServiceBus.DataBus.AzureBlobStorage.Tests, PublicKey=0024000004800000940000000602000000240000525341310004000001000100dde965e6172e019ac82c2639ffe494dd2e7dd16347c34762a05732b492e110f2e4e2e1b5ef2d85c848ccfb671ee20a47c8d1376276708dc30a90ff1121b647ba3b7259a6bc383b2034938ef0e275b58b920375ac605076178123693c6c4f1331661a62eba28c249386855637780e3ff5f23a6d854700eaa6803ef48907513b92")]

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -16,4 +16,9 @@
     <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="SourceLink.Create.GitHub" Version="2.5.0" PrivateAssets="All" />
+    <DotNetCliToolReference Include="dotnet-sourcelink-git" Version="2.5.0" />
+  </ItemGroup>
+
 </Project>

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -1,35 +1,19 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
-  
+
   <PropertyGroup>
     <TargetFrameworks>net452;netstandard2.0</TargetFrameworks>
-    <AssemblyName>NServiceBus.DataBus.AzureBlobStorage</AssemblyName>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
-    <GenerateDocumentationFile>true</GenerateDocumentationFile>
-  </PropertyGroup>
-  
-  <PropertyGroup>
     <Description>NServiceBus AzureBlobStorage DataBus</Description>
   </PropertyGroup>
-  
+
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0-*, 8.0.0)" />
-    <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="all" />
-    <PackageReference Include="Fody" Version="2.1.2" PrivateAssets="all" />
-    <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="all" />
-    <PackageReference Include="Particular.Packaging" Version="*" PrivateAssets="All" />
-
-    <PackageReference Include="WindowsAzure.Storage" Version="[8.0.0,9.0.0)" />
-    <!-- specific versions of the dependencies are required for propers netstandard support -->
-    <PackageReference Include="Microsoft.Data.Edm" Version="5.8.2" />
-    <PackageReference Include="Microsoft.Data.OData" Version="5.8.2" />
-    <PackageReference Include="Microsoft.Data.Services.Client" Version="5.8.2" />
-    <PackageReference Include="System.ComponentModel.EventBasedAsync" Version="4.3.0" />
-    <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
-    <PackageReference Include="System.Linq.Queryable" Version="4.3.0" />
-    <PackageReference Include="System.Net.Requests" Version="4.3.0" />
-    <PackageReference Include="System.Spatial" Version="5.8.2" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[8.2.0, 9.0.0)" />
+    <PackageReference Include="Fody" Version="2.1.2" PrivateAssets="All" />
+    <PackageReference Include="Obsolete.Fody" Version="4.2.4" PrivateAssets="All" />
+    <PackageReference Include="Particular.CodeRules" Version="0.2.0" PrivateAssets="All" />
+    <PackageReference Include="Particular.Packaging" Version="0.1.0" PrivateAssets="All" />
   </ItemGroup>
-  
+
 </Project>

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,8 +1,8 @@
 <Project>
 
   <PropertyGroup>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <LangVersion>latest</LangVersion>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
 
 </Project>

--- a/src/NServiceBus.DataBus.AzureBlobStorage.sln
+++ b/src/NServiceBus.DataBus.AzureBlobStorage.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26730.3
+VisualStudioVersion = 15.0.27004.2006
 MinimumVisualStudioVersion = 15.0.26430.12
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.DataBus.AzureBlobStorage", "DataBus\NServiceBus.DataBus.AzureBlobStorage.csproj", "{FB6302D6-25DC-470D-876E-D36EF81AFC97}"
 EndProject
@@ -13,6 +13,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "nuget", "nuget", "{4B9FD4F1
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests", "AcceptanceTests\NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj", "{30D8D310-671A-4C18-B0D7-1F16F46A5C83}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{9CF39E87-655A-45D8-A274-024832E43E36}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Build.props = Directory.Build.props
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution

--- a/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
+++ b/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
@@ -1,38 +1,27 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
   <PropertyGroup>
     <TargetFrameworks>net452;netcoreapp2.0</TargetFrameworks>
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>$(SolutionDir)NServiceBus.snk</AssemblyOriginatorKeyFile>
     <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
-    <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Remove="APIApprovals.Approve.received.txt" />
-  </ItemGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\DataBus\NServiceBus.DataBus.AzureBlobStorage.csproj" />
   </ItemGroup>
 
-  <!-- Force latest versions -->
   <ItemGroup>
-    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
     <PackageReference Include="NServiceBus" Version="7.0.0-*" />
+    <PackageReference Include="WindowsAzure.Storage" Version="8.*" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
     <PackageReference Include="NUnit" Version="3.7.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.8.0-alpha1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.3.0" />
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' == 'net452'">
     <PackageReference Include="ApprovalTests" Version="3.*" />
-    <PackageReference Include="Mono.Cecil" Version="0.10.0-*" />
-    <PackageReference Include="PublicApiGenerator" Version="6.1.0-*" />
+    <PackageReference Include="PublicApiGenerator" Version="6.*" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Service Include="{82a7f48d-3b50-4b1e-b82e-3ada8210c358}" />
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
This cleans up a few things related to moving to the new project system and Particular.Packaging.

It also adds SourceLink support.

Note that this bumps the minimum WindowsAzure.Storage version to 8.2.0 to resolve issues with netstandard2.0, the same as the projects that reference that package have done.