### PR TITLE
DataBus limits all outgoing HTTP connections to 1

### DIFF
--- a/src/DataBus/BlobStorageDataBus.cs
+++ b/src/DataBus/BlobStorageDataBus.cs
@@ -4,7 +4,6 @@ namespace NServiceBus.DataBus.AzureBlobStorage
     using System.Globalization;
     using System.IO;
     using System.Linq;
-    using System.Net;
     using System.Threading.Tasks;
     using Logging;
     using Microsoft.WindowsAzure.Storage;
@@ -51,7 +50,6 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
         public async Task Start()
         {
-            ServicePointManager.DefaultConnectionLimit = settings.NumberOfIOThreads;
             await container.CreateIfNotExistsAsync().ConfigureAwait(false);
 
             if (settings.ShouldPerformCleanup())


### PR DESCRIPTION
Backport of #59 for release-2.1 branch