### PR TITLE
Managed identity support v2

### DIFF
--- a/src/AcceptanceTests/When_authenticating_with_managed_identity.cs
+++ b/src/AcceptanceTests/When_authenticating_with_managed_identity.cs
@@ -1,12 +1,11 @@
 ﻿using System;
-using Microsoft.WindowsAzure.Storage.Auth;
 using NServiceBus;
 using NUnit.Framework;
 
-public class When_configuring_token_provider_and_connection_string
+public class When_authenticating_with_managed_identity
 {
     [Test]
-    public void Should_throw()
+    public void Should_throw_if_connection_string_is_also_provided()
     {
         var endpointConfiguration = new EndpointConfiguration("AzureBlobStorageDataBus.Test");
         endpointConfiguration.SendFailedMessagesTo("error");
@@ -16,7 +15,7 @@ public class When_configuring_token_provider_and_connection_string
 
         var dataBus = endpointConfiguration.UseDataBus<AzureDataBus>();
         dataBus.ConnectionString("user-provided-connection-string");
-        dataBus.UseTokenCredentialForAccount(new TokenCredential(""), "user-provided-storage-account-name");
+        dataBus.AuthenticateWithManagedIdentity("user-provided-storage-account-name", TimeSpan.FromMinutes(5));
 
         Assert.ThrowsAsync<Exception>(() => Endpoint.Start(endpointConfiguration));
     }

--- a/src/AcceptanceTests/When_configuring_token_provider_and_connection_string.cs
+++ b/src/AcceptanceTests/When_configuring_token_provider_and_connection_string.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Microsoft.WindowsAzure.Storage.Auth;
+using NServiceBus;
+using NUnit.Framework;
+
+public class When_configuring_token_provider_and_connection_string
+{
+    [Test]
+    public void Should_throw()
+    {
+        var endpointConfiguration = new EndpointConfiguration("AzureBlobStorageDataBus.Test");
+        endpointConfiguration.SendFailedMessagesTo("error");
+        endpointConfiguration.UseTransport<LearningTransport>();
+        endpointConfiguration.UsePersistence<InMemoryPersistence>();
+        endpointConfiguration.EnableInstallers();
+
+        var dataBus = endpointConfiguration.UseDataBus<AzureDataBus>();
+        dataBus.ConnectionString("user-provided-connection-string");
+        dataBus.UseTokenCredentialForAccount(new TokenCredential(""), "user-provided-storage-account-name");
+
+        Assert.ThrowsAsync<Exception>(() => Endpoint.Start(endpointConfiguration));
+    }
+}

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -1,7 +1,10 @@
 namespace NServiceBus.DataBus.AzureBlobStorage
 {
     using System;
+    using System.Threading;
+    using System.Threading.Tasks;
     using Features;
+    using Microsoft.Azure.Services.AppAuthentication;
     using Microsoft.WindowsAzure.Storage;
     using Microsoft.WindowsAzure.Storage.Auth;
     using Microsoft.WindowsAzure.Storage.Blob;
@@ -28,7 +31,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
         static void ThrowIfConnectionStringAndTokenProviderSpecified(DataBusSettings dataBusSettings)
         {
-            if (dataBusSettings.TokenCredential != null && dataBusSettings.UserProvidedConnectionString)
+            if (dataBusSettings.RenewalTimeBeforeTokenExpires != null && dataBusSettings.UserProvidedConnectionString)
             {
                 throw new Exception("More than one method to connect to the storage account was supplied (using connection string and token provider). Use one method only.");
             }
@@ -39,10 +42,15 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             CloudBlobContainer container;
 
             // Attempt managed identity identity first
-            if (dataBusSettings.TokenCredential != null)
+            if (!string.IsNullOrWhiteSpace(dataBusSettings.StorageAccountName))
             {
-                var storageCredentials = new StorageCredentials(dataBusSettings.TokenCredential);
+                var azureServiceTokenProvider = new AzureServiceTokenProvider();
+                var state = (azureServiceTokenProvider, dataBusSettings.RenewalTimeBeforeTokenExpires);
+                var tokenAndFrequency = TokenRenewerAsync(state, CancellationToken.None).GetAwaiter().GetResult();
+                var tokenCredential = new TokenCredential(tokenAndFrequency.Token, TokenRenewerAsync, azureServiceTokenProvider, tokenAndFrequency.Frequency.Value);
+                var storageCredentials = new StorageCredentials(tokenCredential);
                 var containerPath = $"https://{dataBusSettings.StorageAccountName}.blob.core.windows.net/{dataBusSettings.Container}";
+
                 container = new CloudBlobContainer(new StorageUri(new Uri(containerPath)), storageCredentials);
             }
             else // fallback to connection string
@@ -52,6 +60,23 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             }
 
             return container;
+        }
+
+        static async Task<NewTokenAndFrequency> TokenRenewerAsync(object state, CancellationToken token = default)
+        {
+            var (azureServiceTokenProvider, renewal) = (ValueTuple<AzureServiceTokenProvider, TimeSpan>)state;
+
+            // Use the same token provider to request a new token.
+            var result = await azureServiceTokenProvider.GetAuthenticationResultAsync("https://storage.azure.com", cancellationToken: token).ConfigureAwait(false);
+
+            // Renew the token before it expires.
+            var next = (result.ExpiresOn - DateTimeOffset.UtcNow) - renewal;
+            if (next.Ticks < 0)
+            {
+                next = default;
+            }
+
+            return new NewTokenAndFrequency(result.AccessToken, next);
         }
     }
 }

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -17,7 +17,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         {
             var dataBusSettings = context.Settings.GetOrDefault<DataBusSettings>() ?? new DataBusSettings();
 
-            // TODO: guard against scenario when both TokenCredential and connection string are provided
+            ThrowIfConnectionStringAndTokenProviderProvided(dataBusSettings);
 
             CloudBlobContainer container;
 
@@ -37,6 +37,14 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             var dataBus = new BlobStorageDataBus(container, dataBusSettings, new AsyncTimer());
 
             context.Container.ConfigureComponent(b => dataBus, DependencyLifecycle.SingleInstance);
+        }
+
+        static void ThrowIfConnectionStringAndTokenProviderProvided(DataBusSettings dataBusSettings)
+        {
+            if (dataBusSettings.ConnectionString != null && dataBusSettings.TokenCredential != null)
+            {
+                throw new Exception("More than one method to connect to the storage account was supplied (connection string and token provider supplied). Use only one method.");
+            }
         }
     }
 }

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -49,7 +49,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
                 var tokenAndFrequency = TokenRenewerAsync(state, CancellationToken.None).GetAwaiter().GetResult();
                 var tokenCredential = new TokenCredential(tokenAndFrequency.Token, TokenRenewerAsync, azureServiceTokenProvider, tokenAndFrequency.Frequency.Value);
                 var storageCredentials = new StorageCredentials(tokenCredential);
-                var containerPath = $"https://{dataBusSettings.StorageAccountName}.blob.core.windows.net/{dataBusSettings.Container}";
+                var containerPath = $"https://{dataBusSettings.StorageAccountName}.blob.{dataBusSettings.EndpointSuffix}/{dataBusSettings.Container}";
 
                 container = new CloudBlobContainer(new StorageUri(new Uri(containerPath)), storageCredentials);
             }

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -31,7 +31,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
         static void ThrowIfConnectionStringAndTokenProviderSpecified(DataBusSettings dataBusSettings)
         {
-            if (dataBusSettings.RenewalTimeBeforeTokenExpires != null && dataBusSettings.UserProvidedConnectionString)
+            if (dataBusSettings.StorageAccountName != null && dataBusSettings.UserProvidedConnectionString)
             {
                 throw new Exception("More than one authentication method to Azure Service was supplied (using connection string and Managed Identity). Use one method only.");
             }

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -33,7 +33,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         {
             if (dataBusSettings.RenewalTimeBeforeTokenExpires != null && dataBusSettings.UserProvidedConnectionString)
             {
-                throw new Exception("More than one method to connect to the storage account was supplied (using connection string and token provider). Use one method only.");
+                throw new Exception("More than one authentication method to Azure Service was supplied (using connection string and Managed Identity). Use one method only.");
             }
         }
 

--- a/src/DataBus/AzureDataBusPersistence.cs
+++ b/src/DataBus/AzureDataBusPersistence.cs
@@ -17,18 +17,18 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         {
             var dataBusSettings = context.Settings.GetOrDefault<DataBusSettings>() ?? new DataBusSettings();
 
-            ThrowIfConnectionStringAndTokenProviderProvided(dataBusSettings);
+            ThrowIfConnectionStringAndTokenProviderSpecified(dataBusSettings);
 
             CloudBlobContainer container;
 
-            // using managed identity
+            // Attempt managed identity identity first
             if (dataBusSettings.TokenCredential != null)
             {
                 var storageCredentials = new StorageCredentials(dataBusSettings.TokenCredential);
                 var containerPath = $"https://{dataBusSettings.StorageAccountName}.blob.core.windows.net/{dataBusSettings.Container}";
                 container = new CloudBlobContainer(new StorageUri(new Uri(containerPath)), storageCredentials);
             }
-            else // using connection string
+            else // fallback to connection string
             {
                 var cloudBlobClient = CloudStorageAccount.Parse(dataBusSettings.ConnectionString).CreateCloudBlobClient();
                 container = cloudBlobClient.GetContainerReference(dataBusSettings.Container);
@@ -39,11 +39,11 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             context.Container.ConfigureComponent(b => dataBus, DependencyLifecycle.SingleInstance);
         }
 
-        static void ThrowIfConnectionStringAndTokenProviderProvided(DataBusSettings dataBusSettings)
+        static void ThrowIfConnectionStringAndTokenProviderSpecified(DataBusSettings dataBusSettings)
         {
-            if (dataBusSettings.ConnectionString != null && dataBusSettings.TokenCredential != null)
+            if (dataBusSettings.TokenCredential != null && dataBusSettings.UserProvidedConnectionString)
             {
-                throw new Exception("More than one method to connect to the storage account was supplied (connection string and token provider supplied). Use only one method.");
+                throw new Exception("More than one method to connect to the storage account was supplied (using connection string and token provider). Use one method only.");
             }
         }
     }

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -165,7 +165,11 @@
         ///  Sets token credential to authenticate with Storage Blob service
         /// <remarks>Token credentials can be created using <see cref="AzureServiceTokenProvider"/> with token renewal configured.</remarks>
         /// </summary>
-        public static DataBusExtensions<AzureDataBus> AuthenticateWithManagedIdentity(this DataBusExtensions<AzureDataBus> config, string storageAccountName, TimeSpan renewalTimeBeforeTokenExpires)
+        /// <param name="config"></param>
+        /// <param name="storageAccountName"></param>
+        /// <param name="renewalTimeBeforeTokenExpires"></param>
+        /// <param name="endpointSuffix">Endpoint suffix associated with storage blob service per type of data center. Default is "core.windows.net" for public Azure data centers.</param>
+        public static DataBusExtensions<AzureDataBus> AuthenticateWithManagedIdentity(this DataBusExtensions<AzureDataBus> config, string storageAccountName, TimeSpan renewalTimeBeforeTokenExpires, string endpointSuffix = "core.windows.net")
         {
             if (renewalTimeBeforeTokenExpires <= TimeSpan.Zero)
             {
@@ -181,6 +185,7 @@
 
             dataBusSettings.RenewalTimeBeforeTokenExpires = renewalTimeBeforeTokenExpires;
             dataBusSettings.StorageAccountName = storageAccountName;
+            dataBusSettings.EndpointSuffix = endpointSuffix;
 
             return config;
         }

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -6,7 +6,6 @@
     using DataBus;
     using DataBus.AzureBlobStorage;
     using Microsoft.Azure.Services.AppAuthentication;
-    using Microsoft.WindowsAzure.Storage.Auth;
 
     /// <summary>
     /// Configuration options for the Azure BlobStorage DataBus.

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -116,7 +116,7 @@
         /// </summary>
         public static DataBusExtensions<AzureDataBus> BasePath(this DataBusExtensions<AzureDataBus> config, string basePath)
         {
-            var value = basePath != null ? basePath : " ";
+            var value = basePath ?? " ";
             var spacesOnly = value.Trim().Length == 0 && value.Length != 0;
 
             if (spacesOnly)

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -166,6 +166,33 @@
         ///  Sets token credential to authenticate with Storage Blob service
         /// <remarks>Token credentials can be created using <see cref="AzureServiceTokenProvider"/> with token renewal configured.</remarks>
         /// </summary>
+        /// <example>
+        /// Creating a token provider
+        /// <code>
+        ///  var azureServiceTokenProvider = new AzureServiceTokenProvider();
+        ///  var tokenAndFrequency = await TokenRenewerAsync(azureServiceTokenProvider, cancellationToken);
+        ///  var tokenCredential = new TokenCredential(initialToken: string, periodicTokenRenewer: RenewTokenFuncAsync, state: azureServiceTokenProvider, renewFrequency: TimeSpan);
+        /// </code>
+        /// </example>
+        /// <example>
+        /// Defining a periodic token renewer callback
+        /// <code>
+        ///  static async Task&lt;NewTokenAndFrequency&gt; TokenRenewerAsync(object state, CancellationToken token = default)
+        ///  {
+        ///    // Use the same token provider to request a new token.
+        ///    var result = await((AzureServiceTokenProvider)state).GetAuthenticationResultAsync("https://storage.azure.com", cancellationToken: token);
+        ///
+        ///    // Renew the token 5 minutes before it expires.
+        ///    var next = (result.ExpiresOn - DateTimeOffset.UtcNow) - TimeSpan.FromMinutes(5);
+        ///    if (next.Ticks &lt; 0)
+        ///    {
+        ///      next = default(TimeSpan);
+        ///    }
+        ///
+        ///    return new NewTokenAndFrequency(result.AccessToken, next);
+        ///  }
+        /// </code>
+        /// </example>
         public static DataBusExtensions<AzureDataBus> UseTokenCredentialForAccount(this DataBusExtensions<AzureDataBus> config, TokenCredential tokenCredential, string storageAccountName)
         {
             if (tokenCredential == null)

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -84,7 +84,11 @@
                 throw new ArgumentException("Should not be an empty string.", nameof(connectionString));
             }
 
-            GetSettings(config).ConnectionString = connectionString;
+            var dataBusSettings = GetSettings(config);
+
+            dataBusSettings.ConnectionString = connectionString;
+            dataBusSettings.UserProvidedConnectionString = true;
+
             return config;
         }
 

--- a/src/DataBus/ConfigureAzureDataBus.cs
+++ b/src/DataBus/ConfigureAzureDataBus.cs
@@ -5,6 +5,8 @@
     using Configuration.AdvancedExtensibility;
     using DataBus;
     using DataBus.AzureBlobStorage;
+    using Microsoft.Azure.Services.AppAuthentication;
+    using Microsoft.WindowsAzure.Storage.Auth;
 
     /// <summary>
     /// Configuration options for the Azure BlobStorage DataBus.
@@ -136,6 +138,7 @@
             {
                 throw new ArgumentOutOfRangeException(nameof(defaultTTLInSeconds), defaultTTLInSeconds, "Should not be negative.");
             }
+
             GetSettings(config).TTL = defaultTTLInSeconds;
             return config;
         }
@@ -150,7 +153,32 @@
             {
                 throw new ArgumentOutOfRangeException(nameof(cleanupInterval), cleanupInterval, "Should not be negative.");
             }
+
             GetSettings(config).CleanupInterval = cleanupInterval;
+            return config;
+        }
+
+        /// <summary>
+        ///  Sets token credential to authenticate with Storage Blob service
+        /// <remarks>Token credentials can be created using <see cref="AzureServiceTokenProvider"/> with token renewal configured.</remarks>
+        /// </summary>
+        public static DataBusExtensions<AzureDataBus> UseTokenCredentialForAccount(this DataBusExtensions<AzureDataBus> config, TokenCredential tokenCredential, string storageAccountName)
+        {
+            if (tokenCredential == null)
+            {
+                throw new ArgumentException("Should not be null", nameof(tokenCredential));
+            }
+
+            if (string.IsNullOrWhiteSpace(storageAccountName))
+            {
+                throw new ArgumentException("Should not be null or empty", nameof(storageAccountName));
+            }
+
+            var dataBusSettings = GetSettings(config);
+
+            dataBusSettings.TokenCredential = tokenCredential;
+            dataBusSettings.StorageAccountName = storageAccountName;
+
             return config;
         }
 

--- a/src/DataBus/DataBusSettings.cs
+++ b/src/DataBus/DataBusSettings.cs
@@ -16,6 +16,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             CleanupInterval = 0; // milliseconds, off by default
             RenewalTimeBeforeTokenExpires = TimeSpan.FromMinutes(5);
             StorageAccountName = null;
+            EndpointSuffix = null;
             ConnectionString = "UseDevelopmentStorage=true";
             UserProvidedConnectionString = false;
         }
@@ -35,6 +36,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         public int CleanupInterval;
         public TimeSpan RenewalTimeBeforeTokenExpires;
         public string StorageAccountName;
+        public string EndpointSuffix;
         public string ConnectionString;
         public bool UserProvidedConnectionString;
     }

--- a/src/DataBus/DataBusSettings.cs
+++ b/src/DataBus/DataBusSettings.cs
@@ -4,21 +4,20 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
     class DataBusSettings
     {
-        public const string DevelopmentStorageConnectionString = "UseDevelopmentStorage=true";
-
         public DataBusSettings()
         {
             Container = "databus";
             BasePath = "";
             MaxRetries = 5;
             NumberOfIOThreads = 1;
-            ConnectionString = DevelopmentStorageConnectionString;
             BlockSize = 4 * 1024 * 1024; // Maximum 4MB
             BackOffInterval = 30; // seconds
             TTL = long.MaxValue; // seconds
             CleanupInterval = 0; // milliseconds, off by default
             TokenCredential = null;
             StorageAccountName = null;
+            ConnectionString = "UseDevelopmentStorage=true";
+            UserProvidedConnectionString = false;
         }
 
         public bool ShouldPerformCleanup()
@@ -26,7 +25,6 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             return CleanupInterval > 0;
         }
 
-        public string ConnectionString;
         public string Container;
         public int MaxRetries;
         public int BackOffInterval;
@@ -37,5 +35,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         public int CleanupInterval;
         public TokenCredential TokenCredential;
         public string StorageAccountName;
+        public string ConnectionString;
+        public bool UserProvidedConnectionString;
     }
 }

--- a/src/DataBus/DataBusSettings.cs
+++ b/src/DataBus/DataBusSettings.cs
@@ -1,6 +1,6 @@
 namespace NServiceBus.DataBus.AzureBlobStorage
 {
-    using Microsoft.WindowsAzure.Storage.Auth;
+    using System;
 
     class DataBusSettings
     {
@@ -14,7 +14,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             BackOffInterval = 30; // seconds
             TTL = long.MaxValue; // seconds
             CleanupInterval = 0; // milliseconds, off by default
-            TokenCredential = null;
+            RenewalTimeBeforeTokenExpires = TimeSpan.FromMinutes(5);
             StorageAccountName = null;
             ConnectionString = "UseDevelopmentStorage=true";
             UserProvidedConnectionString = false;
@@ -33,7 +33,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         public int BlockSize;
         public long TTL;
         public int CleanupInterval;
-        public TokenCredential TokenCredential;
+        public TimeSpan RenewalTimeBeforeTokenExpires;
         public string StorageAccountName;
         public string ConnectionString;
         public bool UserProvidedConnectionString;

--- a/src/DataBus/DataBusSettings.cs
+++ b/src/DataBus/DataBusSettings.cs
@@ -4,13 +4,15 @@ namespace NServiceBus.DataBus.AzureBlobStorage
 
     class DataBusSettings
     {
+        public const string DevelopmentStorageConnectionString = "UseDevelopmentStorage=true";
+
         public DataBusSettings()
         {
             Container = "databus";
             BasePath = "";
             MaxRetries = 5;
             NumberOfIOThreads = 1;
-            ConnectionString = "UseDevelopmentStorage=true";
+            ConnectionString = DevelopmentStorageConnectionString;
             BlockSize = 4 * 1024 * 1024; // Maximum 4MB
             BackOffInterval = 30; // seconds
             TTL = long.MaxValue; // seconds
@@ -19,7 +21,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             StorageAccountName = null;
         }
 
-        internal bool ShouldPerformCleanup()
+        public bool ShouldPerformCleanup()
         {
             return CleanupInterval > 0;
         }

--- a/src/DataBus/DataBusSettings.cs
+++ b/src/DataBus/DataBusSettings.cs
@@ -1,5 +1,7 @@
 namespace NServiceBus.DataBus.AzureBlobStorage
 {
+    using Microsoft.WindowsAzure.Storage.Auth;
+
     class DataBusSettings
     {
         public DataBusSettings()
@@ -13,6 +15,8 @@ namespace NServiceBus.DataBus.AzureBlobStorage
             BackOffInterval = 30; // seconds
             TTL = long.MaxValue; // seconds
             CleanupInterval = 0; // milliseconds, off by default
+            TokenCredential = null;
+            StorageAccountName = null;
         }
 
         internal bool ShouldPerformCleanup()
@@ -29,5 +33,7 @@ namespace NServiceBus.DataBus.AzureBlobStorage
         public int BlockSize;
         public long TTL;
         public int CleanupInterval;
+        public TokenCredential TokenCredential;
+        public string StorageAccountName;
     }
 }

--- a/src/DataBus/FodyWeavers.xml
+++ b/src/DataBus/FodyWeavers.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
-<Weavers>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers GenerateXsd="false">
   <Obsolete />
 </Weavers>

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -10,6 +10,7 @@
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="WindowsAzure.Storage" Version="[9.0.0, 10.0.0)" />
+    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.4.0, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
+    <PackageReference Include="System.ValueTuple" Version="[4.5.0, 5.0.0)" />
     <PackageReference Include="WindowsAzure.Storage" Version="[9.3.3, 10.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.4.0, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="All" />

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -9,13 +9,16 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
-    <PackageReference Include="System.ValueTuple" Version="[4.5.0, 5.0.0)" />
     <PackageReference Include="WindowsAzure.Storage" Version="[9.3.3, 10.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.4.0, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.0" PrivateAssets="All" />
     <PackageReference Include="Particular.CodeRules" Version="0.2.1" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="0.5.0" PrivateAssets="All" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'" Label="Needed for net452">
+    <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
 
 </Project>

--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
-    <PackageReference Include="WindowsAzure.Storage" Version="[9.0.0, 10.0.0)" />
+    <PackageReference Include="WindowsAzure.Storage" Version="[9.3.3, 10.0.0)" />
     <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.4.0, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.1.1" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.2.0" PrivateAssets="All" />

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -18,5 +18,6 @@ namespace NServiceBus
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> DefaultTTL(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, long defaultTTLInSeconds) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> MaxRetries(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int maxRetries) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> NumberOfIOThreads(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int numberOfIOThreads) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> UseTokenCredentialForAccount(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, Microsoft.WindowsAzure.Storage.Auth.TokenCredential tokenCredential, string storageAccountName) { }
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -9,6 +9,7 @@ namespace NServiceBus
     }
     public class static ConfigureAzureDataBus
     {
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> AuthenticateWithManagedIdentity(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string storageAccountName, System.TimeSpan renewalTimeBeforeTokenExpires) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BackOffInterval(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int backOffInterval) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BasePath(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string basePath) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BlockSize(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int blockSize) { }
@@ -18,6 +19,5 @@ namespace NServiceBus
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> DefaultTTL(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, long defaultTTLInSeconds) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> MaxRetries(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int maxRetries) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> NumberOfIOThreads(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int numberOfIOThreads) { }
-        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> UseTokenCredentialForAccount(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, Microsoft.WindowsAzure.Storage.Auth.TokenCredential tokenCredential, string storageAccountName) { }
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -9,7 +9,7 @@ namespace NServiceBus
     }
     public class static ConfigureAzureDataBus
     {
-        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> AuthenticateWithManagedIdentity(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string storageAccountName, System.TimeSpan renewalTimeBeforeTokenExpires) { }
+        public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> AuthenticateWithManagedIdentity(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string storageAccountName, System.TimeSpan renewalTimeBeforeTokenExpires, string endpointSuffix = "core.windows.net") { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BackOffInterval(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int backOffInterval) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BasePath(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, string basePath) { }
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BlockSize(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int blockSize) { }

--- a/src/Tests/When_using_AzureDataBusGuard.cs
+++ b/src/Tests/When_using_AzureDataBusGuard.cs
@@ -82,6 +82,21 @@
             Assert.Throws<ArgumentOutOfRangeException>(() => config.CleanupInterval(-1));
         }
 
+        [TestCase("0.00:00:00")]
+        [TestCase("-0.00:01:00")]
+        public void Should_not_allow_managed_identity_authentication_with_renewal_time_of_less_or_equal_than_timespan_zero(string renewBeforeExpires)
+        {
+            var value = TimeSpan.Parse(renewBeforeExpires);
+            Assert.Throws<ArgumentException>(() => config.AuthenticateWithManagedIdentity("account", value));
+        }
+
+        [TestCase(null)]
+        [TestCase(" ")]
+        public void Should_not_allow_managed_identity_authentication_with_no_account_name_specified(string accountName)
+        {
+            Assert.Throws<ArgumentException>(() => config.AuthenticateWithManagedIdentity(accountName, TimeSpan.MaxValue));
+        }
+
         DataBusExtensions<AzureDataBus> config = new DataBusExtensions<AzureDataBus>(new SettingsHolder());
     }
 }


### PR DESCRIPTION
Closes #61
Replaces #90 

This PR removes the need to supply TokenCredential by users. Instead, API will only require a storage account name and the time when to auto-renew the token before it expires.

```c#
dataBus.AuthenticateWithManagedIdentity("accountname", TimeSpan.FromMinutes(5));
```