### PR TITLE
Remove unneeded dependency on Microsoft.Azure.Services.AppAuthentication

### DIFF
--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.13.1, 13.0.0)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="NServiceBus" Version="[8.0.0-rc.3, 9)" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.6.2, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />

--- a/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
+++ b/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
@@ -12,8 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-    <!-- DO NOT REMOVE Microsoft.Azure.Services.AppAuthentication, it is added so that dependabot knows about version changes-->
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="NServiceBus" Version="8.0.0-rc.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
It appears the dependency was added to [support managed identity](https://github.com/Particular/NServiceBus.DataBus.AzureBlobStorage/pull/91/files#diff-f4a8ff27fe56a1207b6ce24b3185b494ee969acc9418d8c405bd2f2412d26beb) but that one of the following Azure SDK updates made this unnecessary. In version 4 the [AuthenticateWithManagedIdentity method was marked as obsolete](https://github.com/Particular/NServiceBus.DataBus.AzureBlobStorage/blob/release-4.0/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt#L12), and then was removed in the [version 5 API](https://github.com/Particular/NServiceBus.DataBus.AzureBlobStorage/blob/release-5.0/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt).

Additionally, the package is not a transitive dependency that is included to lock versions. Without it included in the project file, the assembly does not show up in the build output, and (I presume) the tests on this PR will pass as well.

So it just doesn't need to be there.

Side question: Does this need to be backported to the release-5.0 branch as an RC bugfix?