### PR TITLE
 Remove unneeded dependency on Microsoft.Azure.Services.AppAuthentication

### DIFF
--- a/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
+++ b/src/DataBus/NServiceBus.DataBus.AzureBlobStorage.csproj
@@ -11,7 +11,6 @@
     <PackageReference Include="Azure.Storage.Blobs" Version="[12.13.1, 13.0.0)" />
     <PackageReference Include="Microsoft.IO.RecyclableMemoryStream" Version="2.2.1" />
     <PackageReference Include="NServiceBus" Version="[8.0.0-rc.3, 9)" />
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="[1.6.2, 2.0.0)" />
     <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Particular.Packaging" Version="2.2.0" PrivateAssets="All" />

--- a/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
+++ b/src/Tests/NServiceBus.DataBus.AzureBlobStorage.Tests.csproj
@@ -12,8 +12,6 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Storage.Blobs" Version="12.13.1" />
-    <!-- DO NOT REMOVE Microsoft.Azure.Services.AppAuthentication, it is added so that dependabot knows about version changes-->
-    <PackageReference Include="Microsoft.Azure.Services.AppAuthentication" Version="1.6.2" />
     <PackageReference Include="NServiceBus" Version="8.0.0-rc.3" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.3.1" />
     <PackageReference Include="NUnit" Version="3.13.3" />


### PR DESCRIPTION
Bring https://github.com/Particular/NServiceBus.DataBus.AzureBlobStorage/pull/411 to the `release-5.0` branch