### PR TITLE
Fix build warning

### DIFF
--- a/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
+++ b/src/AcceptanceTests/NServiceBus.DataBus.AzureBlobStorage.AcceptanceTests.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="GitHubActionsTestLogger" Version="2.3.3" />
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup Condition="'$(PkgNServiceBus_AcceptanceTests_Sources)' != ''">
     <Compile Remove="$(PkgNServiceBus_AcceptanceTests_Sources)\**\*.cs" />
     <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\contentFiles\cs\$(TargetFramework)\**\EndpointTemplates\*.cs" />
     <Compile Include="$(PkgNServiceBus_AcceptanceTests_Sources)\contentFiles\cs\$(TargetFramework)\**\ScenarioDescriptors\*.cs" />


### PR DESCRIPTION
This PR includes a fix for the build warnings from the compile items referencing the generated package path property.