### PR TITLE
Simplify obsolete messages

### DIFF
--- a/src/DataBus/obsoletes_v7.cs
+++ b/src/DataBus/obsoletes_v7.cs
@@ -5,11 +5,8 @@ namespace NServiceBus.DataBus.AzureBlobStorage
     using System;
     using Particular.Obsoletes;
 
-    [ObsoleteMetadata(Message = "NServiceBus.DataBus.AzureBlobStorage.IProvideBlobServiceClient has been replaced by NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7",
-        ReplacementTypeOrMember = "NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient")]
-    [Obsolete("NServiceBus.DataBus.AzureBlobStorage.IProvideBlobServiceClient has been replaced by NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient. Use 'NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient' instead. Will be removed in version 8.0.0.", true)]
+    [ObsoleteMetadata(ReplacementTypeOrMember = "NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient", TreatAsErrorFromVersion = "7", RemoveInVersion = "8")]
+    [Obsolete("Use 'NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient' instead. Will be removed in version 8.0.0.", true)]
     public interface IProvideBlobServiceClient : ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient
     {
     }
@@ -22,26 +19,17 @@ namespace NServiceBus
     using DataBus;
     using Particular.Obsoletes;
 
-    [ObsoleteMetadata(Message = "AzureDataBus has been replaced by AzureClaimCheck",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7",
-        ReplacementTypeOrMember = "AzureClaimCheck")]
-    [Obsolete("AzureDataBus has been replaced by AzureClaimCheck. Use 'AzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
+    [ObsoleteMetadata(ReplacementTypeOrMember = "AzureClaimCheck", TreatAsErrorFromVersion = "7", RemoveInVersion = "8")]
+    [Obsolete("Use 'AzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
     public class AzureDataBus : DataBusDefinition
     {
-        [ObsoleteMetadata(Message = "AzureDataBus has been replaced by AzureClaimCheck",
-            RemoveInVersion = "8",
-            TreatAsErrorFromVersion = "7",
-            ReplacementTypeOrMember = "AzureClaimCheck")]
-        [Obsolete("AzureDataBus has been replaced by AzureClaimCheck. Use 'AzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
+        [ObsoleteMetadata(ReplacementTypeOrMember = "AzureClaimCheck", TreatAsErrorFromVersion = "7", RemoveInVersion = "8")]
+        [Obsolete("Use 'AzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
         protected override Type ProvidedByFeature() => throw new NotImplementedException();
     }
 
-    [ObsoleteMetadata(Message = "AzureDataBus has been replaced by AzureClaimCheck. These extension methods are replaced by the ones on the AzureClaimCheck type",
-        RemoveInVersion = "8",
-        TreatAsErrorFromVersion = "7",
-        ReplacementTypeOrMember = "AzureClaimCheck")]
-    [Obsolete("AzureDataBus has been replaced by AzureClaimCheck. These extension methods are replaced by the ones on the AzureClaimCheck type. Use 'AzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
+    [ObsoleteMetadata(ReplacementTypeOrMember = "ConfigureAzureClaimCheck", TreatAsErrorFromVersion = "7", RemoveInVersion = "8")]
+    [Obsolete("Use 'ConfigureAzureClaimCheck' instead. Will be removed in version 8.0.0.", true)]
     public static class ConfigureAzureDataBus
     {
         public static DataBusExtensions<AzureDataBus> MaxRetries(this DataBusExtensions<AzureDataBus> config, int maxRetries) => throw new NotImplementedException();

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -7,13 +7,11 @@ namespace NServiceBus
         public AzureClaimCheck() { }
         protected override System.Type ProvidedByFeature() { }
     }
-    [System.Obsolete("AzureDataBus has been replaced by AzureClaimCheck. Use \'AzureClaimCheck\' instead." +
-        " Will be removed in version 8.0.0.", true)]
+    [System.Obsolete("Use \'AzureClaimCheck\' instead. Will be removed in version 8.0.0.", true)]
     public class AzureDataBus : NServiceBus.DataBus.DataBusDefinition
     {
         public AzureDataBus() { }
-        [System.Obsolete("AzureDataBus has been replaced by AzureClaimCheck. Use \'AzureClaimCheck\' instead." +
-            " Will be removed in version 8.0.0.", true)]
+        [System.Obsolete("Use \'AzureClaimCheck\' instead. Will be removed in version 8.0.0.", true)]
         protected override System.Type ProvidedByFeature() { }
     }
     public static class ConfigureAzureClaimCheck
@@ -26,9 +24,7 @@ namespace NServiceBus
         public static NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.AzureClaimCheck> NumberOfIOThreads(this NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.AzureClaimCheck> config, int numberOfIOThreads) { }
         public static NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.AzureClaimCheck> UseBlobServiceClient(this NServiceBus.ClaimCheck.ClaimCheckExtensions<NServiceBus.AzureClaimCheck> config, Azure.Storage.Blobs.BlobServiceClient blobServiceClient) { }
     }
-    [System.Obsolete("AzureDataBus has been replaced by AzureClaimCheck. These extension methods are re" +
-        "placed by the ones on the AzureClaimCheck type. Use \'AzureClaimCheck\' instead. W" +
-        "ill be removed in version 8.0.0.", true)]
+    [System.Obsolete("Use \'ConfigureAzureClaimCheck\' instead. Will be removed in version 8.0.0.", true)]
     public static class ConfigureAzureDataBus
     {
         public static NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> BackOffInterval(this NServiceBus.DataBus.DataBusExtensions<NServiceBus.AzureDataBus> config, int backOffInterval) { }
@@ -49,6 +45,7 @@ namespace NServiceBus.ClaimCheck.AzureBlobStorage
 }
 namespace NServiceBus.DataBus.AzureBlobStorage
 {
-    [System.Obsolete(@"NServiceBus.DataBus.AzureBlobStorage.IProvideBlobServiceClient has been replaced by NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient. Use 'NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient' instead. Will be removed in version 8.0.0.", true)]
+    [System.Obsolete("Use \'NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient\' instead. " +
+        "Will be removed in version 8.0.0.", true)]
     public interface IProvideBlobServiceClient : NServiceBus.ClaimCheck.AzureBlobStorage.IProvideBlobServiceClient { }
 }


### PR DESCRIPTION
This PR simplifies the obsolete messages by not duplicating the `ReplacementTypeOrMember` information by also specifying a `Message`. 